### PR TITLE
Historic categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is my bookkeeping application. It is heavily opionated and uses Postgres as a Backend, FinTS to synchronize bank account balances and transactions and Supabase to handle sign ins and auth.
 
-## Running it
+## Building it
 
 ```sh
 npm run build
@@ -18,6 +18,7 @@ node ace fints
 
 ## Development
 
-```
+```sh
+docker-compose up -d # to start local DB server
 npm run dev
 ```

--- a/database/categories.ts
+++ b/database/categories.ts
@@ -1,0 +1,48 @@
+import Database from '@ioc:Adonis/Lucid/Database';
+import CategoryModel from 'App/Models/CategoryModel';
+
+export async function wrapUpMonth(date: string) {
+  const [year, month] = date.split('-');
+  const startOfMonth = new Date(parseInt(year), parseInt(month) - 1, 1, 12);
+  const endOfMonth = new Date(parseInt(year), parseInt(month), 0, 23, 59, 59);
+
+  await Database.transaction(async (trx) => {
+    // collect historical data
+    await Database.rawQuery(
+      `INSERT INTO historic_categories (id, category_id, summary, expected_amount, due_date, parent, created_at, updated_at)
+        SELECT gen_random_uuid() AS id,
+                c.id AS category_id,
+                summary,
+                "expectedAmount",
+                COALESCE("dueDate", DATE(?)) AS "date",
+                parent,
+                now(),
+                now()
+        FROM categories c
+        WHERE c."isActive" = true
+        AND ((c."dueDate" BETWEEN ? AND ?) OR c.every IS NULL)
+        ORDER BY date;
+        `,
+      [startOfMonth, startOfMonth, endOfMonth]
+    ).useTransaction(trx);
+
+    // after historical data has been written, update the categories itself and move forward the dueDate
+    const promises = (
+      await CategoryModel.query()
+        .useTransaction(trx)
+        .whereBetween('dueDate', [startOfMonth, endOfMonth])
+    )
+      .map((c: CategoryModel) => {
+        if (c.dueDate === null || c.every === null) {
+          return c;
+        }
+
+        c.dueDate = c.dueDate?.plus({ months: c.every });
+
+        return c;
+      })
+      .map(async (c: CategoryModel) => await c.save());
+
+    await Promise.all(promises);
+  });
+}

--- a/database/migrations/1660225401774_historic_categories.ts
+++ b/database/migrations/1660225401774_historic_categories.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class HistoricCategories extends BaseSchema {
+  protected tableName = 'historic_categories'
+
+  // stores historic data for categories, eg. "in 2022-01 the car budget was 5€"
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').notNullable().primary;
+      table.uuid('category_id').notNullable();
+      table.string('summary', 100).notNullable();
+      table.integer('expected_amount').notNullable();
+      table.timestamp('due_date', { useTz: true }).nullable();
+      table.string('parent', 100).nullable();
+      table.timestamp('created_at', { useTz: true });
+      table.timestamp('updated_at', { useTz: true });
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  postgresql:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: bookkeeping
+    ports:
+      - "5432:5432"

--- a/start/routes/categories.ts
+++ b/start/routes/categories.ts
@@ -1,5 +1,7 @@
 import Route from '@ioc:Adonis/Core/Route';
+
 import CategoryModel from 'App/Models/CategoryModel';
+import { wrapUpMonth } from 'Database/categories';
 
 Route.post('categories', async ({ request }) => {
   await CategoryModel.updateOrCreate(request.body(), request.body());
@@ -12,24 +14,7 @@ Route.get('categories', async () => {
 });
 
 Route.post('close-month/:date', async ({ request }) => {
-  const [year, month] = request.params().date.split('-');
-
-  const startOfMonth = new Date(year, month - 1, 1, 12);
-  const endOfMonth = new Date(year, month, 0, 23, 59, 59);
-
-  const promises = (await CategoryModel.query().whereBetween('dueDate', [startOfMonth, endOfMonth]))
-    .map((c: CategoryModel) => {
-      if (c.dueDate === null || c.every === null) {
-        return c;
-      }
-
-      c.dueDate = c.dueDate?.plus({ months: c.every });
-
-      return c;
-    })
-    .map(async (c: CategoryModel) => await c.save());
-
-  await Promise.all(promises);
+  await wrapUpMonth(request.params().date)
 
   return {};
 });


### PR DESCRIPTION
This will add a new database table `historic_categories` where historical data for categories will be stored when the user clicks the WrapUp-Button in the frontend. Use of the table is purely for analysis to answer the question `What were the planned expenses in July 2021?` and to compare how those have changed over time especially in comparison to the actual expenses.

I also added a basic `docker-compose.yml` to run a PostgreSQL database locally without much developer effort required.